### PR TITLE
Make app compatible with Nextcloud 14

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,12 +6,19 @@
 	<name>Secure remote access (beame-insta-ssl)</name>
 	<summary>Access your Nextcloud securely from the Internet without configuring firewall/router.</summary>
 	<description><![CDATA[beame-insta-ssl makes your Nextcloud accessible from the Internet even if it is behind a firewall or router. You must have beame-insta-ssl npm installed globally. The communication is secured by TLS (HTTPS).]]></description>
-	<category>integration</category>
-	<category>tools</category>
-	<licence>AGPL</licence>
+	<version>0.0.6</version>
+	<licence>agpl</licence>
 	<author>Beame.io LTD</author>
 	<namespace>BeameInstaSsl</namespace>
-	<version>0.0.6</version>
+	<types>
+		<filesystem/>
+	</types>
+	<category>integration</category>
+	<category>tools</category>
+
+	<website>https://github.com/nextcloud/beame_insta_ssl</website>
+	<bugs>https://github.com/nextcloud/beame_insta_ssl/issues</bugs>
+	<repository type="git">https://github.com/nextcloud/beame_insta_ssl.git</repository>
 
 	<screenshot>https://raw.githubusercontent.com/nextcloud/beame_insta_ssl/e09f9f30129c1c703a15cb01090cb9b8f5b459ea/screenshots/running-zoom.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/beame_insta_ssl/e09f9f30129c1c703a15cb01090cb9b8f5b459ea/screenshots/01-not-installed.png</screenshot>
@@ -21,20 +28,13 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/beame_insta_ssl/e09f9f30129c1c703a15cb01090cb9b8f5b459ea/screenshots/05-link-works.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/beame_insta_ssl/e09f9f30129c1c703a15cb01090cb9b8f5b459ea/screenshots/06-crashed.png</screenshot>
 
-	<website>https://github.com/nextcloud/beame_insta_ssl</website>
-	<bugs>https://github.com/nextcloud/beame_insta_ssl/issues</bugs>
-	<repository type="git">https://github.com/nextcloud/beame_insta_ssl.git</repository>
-
-	<types>
-		<filesystem/>
-	</types>
 	<dependencies>
-		<nextcloud min-version="12" max-version="14" />
 		<command>bash</command>
 		<command>env</command>
 		<command>grep</command>
 		<command>nohup</command>
 		<command>ps</command>
+		<nextcloud min-version="12" max-version="14" />
 	</dependencies>
 	<settings>
 		<admin>OCA\BeameInstaSsl\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@
 		<filesystem/>
 	</types>
 	<dependencies>
-		<nextcloud min-version="12" max-version="13" />
+		<nextcloud min-version="12" max-version="14" />
 		<command>bash</command>
 		<command>env</command>
 		<command>grep</command>


### PR DESCRIPTION
Hi,

as you may have already seen, we have entered the beta phase for the release of Nextcloud 14. We try to keep up compatibility with older apps, but in some cases apps need some adjustments to properly work on new Nextcloud releases. With Nextcloud 14 there have been quite some changes in that regard.

However your app seems to run fine, as far as I can tell, so just I just bumped the max-version and applied some reordering to make occ app:check-code run successfully.

We would be very pleased if you can make your app compatible with Nextcloud 14 and release a new version to the app store, so that users can properly test it and the upgrade experience to Nextcloud 14 will be even better than before.

Feel free to ask, if you have any questions regarding making your app compatible with Nextcloud 14.

Thanks for being part of the Nextcloud community and for all the effort you put into providing this app.